### PR TITLE
Upgrade to PHP 8

### DIFF
--- a/Classes/EndpointInterface.php
+++ b/Classes/EndpointInterface.php
@@ -13,10 +13,10 @@ interface EndpointInterface
      * @param ResolveInfo $info
      * @return mixed
      */
-    public function __invoke($objectValue, $args, $_, ResolveInfo $info);
+    public function __invoke($objectValue, $args, $_, ResolveInfo $info): mixed;
 
     /**
-     * Returns the path (ie. a part of the GraphQL API URL) which should
+     * Returns the path (i.e. a part of the GraphQL API URL) which should
      * be handled by this endpoint.
      *
      * The path must be unique across all endpoints of one system.

--- a/Configuration/Objects.yaml
+++ b/Configuration/Objects.yaml
@@ -1,6 +1,6 @@
 Flownative\GraphQL\Middleware:
-  properties:
-    'schemaCache':
+  arguments:
+    1:
       object:
         factoryObjectName: Neos\Flow\Cache\CacheManager
         factoryMethodName: getCache

--- a/README.md
+++ b/README.md
@@ -126,5 +126,5 @@ final class Endpoint implements EndpointInterface
 ## Credits and Support
 
 This library was developed by Robert Lemke / Flownative. Feel free to
-suggest new features, report bugs or provide bug fixes in our Github
+suggest new features, report bugs or provide bug fixes in our GitHub
 project.

--- a/composer.json
+++ b/composer.json
@@ -4,10 +4,14 @@
     "description": "Flownative GraphQL",
     "license": "MIT",
     "require": {
-        "php": "7.4.* || 8.0.* || 8.1.*",
+        "php": "8.0.* || 8.1.* || 8.2.*",
         "ext-json": "*",
         "neos/flow": "^7.0 || ^8.0",
         "webonyx/graphql-php": "^14.0"
+    }
+    ,
+    "require-dev": {
+        "roave/security-advisories": "dev-latest"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This raises the PHP requirement to 8.0 and later and adjusts the code accordingly.

It includes one breaking change because the return type of `__invoke()` is now declared as `mixed`.