### PR TITLE
Raise requirements on Flow and PHP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,9 @@
     "description": "Flownative GraphQL",
     "license": "MIT",
     "require": {
-        "php": "8.0.* || 8.1.* || 8.2.*",
+        "php": "8.1.* || 8.2.* || 8.3.*",
         "ext-json": "*",
-        "neos/flow": "^7.0 || ^8.0 || ^9.0",
+        "neos/flow": "^8.0 || ^9.0",
         "webonyx/graphql-php": "^14.0"
     }
     ,


### PR DESCRIPTION
This declares compatibility with PHP 8.3 and drops support for PHP 8.0. It also drops support for Flow 7.*